### PR TITLE
Add Mataré Gymnasium Meerbusch to popularity list

### DIFF
--- a/popularity.rst
+++ b/popularity.rst
@@ -13,6 +13,7 @@ of schools: 20 in 1982 ([alwr82]_, part 4, p. 13) and 500 secondary schools by
 - Max-Planck-Gymnasium Bielefeld
 - Ceciliengymnasium Bielefeld ([elannewsletter81a]_ p. 21)
 - Gymnasium Wesermünde [eumelspiegel81b]_
+- Mataré Gymnasium Meerbusch
 - Carl Duisberg Gymnasium, Wuppertal [eumelspiegel81b]_
 - Theodor Heuss Gymnasium, Hagen
 - Gymnasium Verl


### PR DESCRIPTION
Mataré Gymnasium ran EUMEL on Z80 until around 1984 with 6 terminals, later on a 80286 with 10 terminals.